### PR TITLE
fix: mktmp with required X suffix

### DIFF
--- a/bin/gdoc-2-codelab.sh
+++ b/bin/gdoc-2-codelab.sh
@@ -27,7 +27,7 @@ if [ ! -d "${CODELAB_DIR}" ] ; then
     mkdir -p "${CODELAB_DIR}"
 fi
 
-TEMP_DIR=$(mktemp -d -t claat-codelab)
+TEMP_DIR=$(mktemp -d -t claat-codelab.XXXXXXXXXX)
 
 pushd "${TEMP_DIR}" &> /dev/null
 $CLAAT export -f html "${GDOC_ID}"

--- a/bin/gdoc-2-markdown.sh
+++ b/bin/gdoc-2-markdown.sh
@@ -26,7 +26,7 @@ if [ ! -d "${QWIKLAB_DIR}" ] ; then
     mkdir -p "${QWIKLAB_DIR}"
 fi
 
-TEMP_DIR=$(mktemp -d -t claat-qwiklab)
+TEMP_DIR=$(mktemp -d -t claat-qwiklab.XXXXXXXXXX)
 
 pushd "${TEMP_DIR}" &> /dev/null
 claat export -f md "${GDOC_ID}"


### PR DESCRIPTION
Tool failed for me without the .XXX suffix (Bash on Linux)